### PR TITLE
Fix PhotoEditorViewController modalPresentationStyle

### DIFF
--- a/PhotoVideoEditor/PhotoVideoEditor/camera/CameraVC.swift
+++ b/PhotoVideoEditor/PhotoVideoEditor/camera/CameraVC.swift
@@ -94,7 +94,7 @@ class CameraVC: SwiftyCamViewController, SwiftyCamViewControllerDelegate {
         for i in 100...110 {
             vc.stickers.append(UIImage(named: i.description )!)
         }
-        
+        vc.modalPresentationStyle = .fullScreen
         present(vc, animated: false, completion: nil)
     }
     


### PR DESCRIPTION
Set PhotoEditorViewController modalPresentationStyle to fullScreen, Otherwise, drawing gesture won't work correctly